### PR TITLE
feat(agent): standardize ansible for agent installation

### DIFF
--- a/util/laceworkagent/ansible/agent.yaml
+++ b/util/laceworkagent/ansible/agent.yaml
@@ -1,0 +1,77 @@
+- hosts: all
+  vars:
+    access_token: "{{ lacework_access_token }}"
+    enable_caa: "{{ lacework_enable_caa | default(false) }}"
+    syscall_template: "{{ lacework_syscall_template | default(undefined) }}"
+    api_server: "{{ lacework_api_server | default('https://api.lacework.net/')}}"
+    agent_version: "{{ lacework_agent_version | default('latest') }}"
+    msi_url: "{{ lacework_msi_url | default(false) }}"
+    msi_final_url: "{% if msi_url %}{{ msi_url }}{% elif agent_version != 'latest' %}https://updates.lacework.net/{{ agent_version }}/LWDataCollector.msi{% else %}https://updates.lacework.net/windows/latest/LWDataCollector.msi{% endif %}"
+  tasks:
+  - name: Update apt repo and cache on all Debian/Ubuntu boxes
+    apt: update_cache=yes force_apt_get=yes cache_valid_time=3600
+    become: true
+    when: ansible_system | lower == 'linux'
+  - name: add apt signing key
+    apt_key:
+      keyserver: hkp://keyserver.ubuntu.com:80
+      id: EE0CC692
+      state: present
+    become: true
+    when: ansible_system | lower == 'linux'
+  - name: add latest lacework repository into source list
+    apt_repository:
+      repo: "deb [arch=amd64] https://packages.lacework.net/latest/DEB/{{ ansible_distribution | lower  }} {{ ansible_distribution_release }} main"
+      filename: lacework
+      state: present
+      update_cache: yes
+    become: true
+    when: ansible_system | lower == 'linux'
+  - name: add established lacework repository into source list
+    apt_repository:
+      repo: "deb [arch=amd64] https://packages.lacework.net/established/DEB/{{ ansible_distribution | lower  }} {{ ansible_distribution_release }} main"
+      filename: lacework
+      state: present
+      update_cache: yes
+    become: true
+    when: ansible_system | lower == 'linux'
+  - name: add archived lacework repository into source list
+    apt_repository:
+      repo: "deb [arch=amd64] https://packages.lacework.net/archived/DEB/{{ ansible_distribution | lower  }} {{ ansible_distribution_release }} main"
+      filename: lacework
+      state: present
+      update_cache: yes
+    become: true
+    when: ansible_system | lower == 'linux'
+  - name: install lacework datacollector
+    apt:
+      name: "{% if agent_version != 'latest'%}lacework={{ agent_version }}{% else %}lacework{% endif %}"
+      allow_downgrade: true
+      state: present
+    become: true
+    when: ansible_system | lower == 'linux'
+  - name: wait until /var/lib/lacework/config/ is created
+    wait_for:
+      path: /var/lib/lacework/config/
+    when: ansible_system | lower == 'linux'
+    become: true
+  - name: write config.json
+    template:
+      src: config.j2
+      dest: /var/lib/lacework/config/config.json
+    become: true
+    when: ansible_system | lower == 'linux'
+  - name: write syscall_config.yaml
+    template:
+      src: "{{ syscall_template }}"
+      dest: /var/lib/lacework/config/syscall_config.yaml
+    become: true
+    when: ansible_system | lower == 'linux' and syscall_template is defined
+
+  - name: Install Lacework Agent MSI
+    ansible.windows.win_package:
+      path: "{{ msi_final_url }}"
+      arguments:
+      - ACCESSTOKEN={{ access_token }}
+      - SERVERURL={{ api_server }}
+    when: ansible_system | lower == 'win32nt'

--- a/util/laceworkagent/ansible/templates/config.j2
+++ b/util/laceworkagent/ansible/templates/config.j2
@@ -1,0 +1,6 @@
+{
+  "serverurl": "{{ api_server }}",
+  "tokens": {"accesstoken": "{{ access_token }}"},
+{% if enable_caa == true %}  "codeaware":{"enable":"true"}{% endif %}
+
+}

--- a/util/laceworkagent/ansible/templates/syscall.j2
+++ b/util/laceworkagent/ansible/templates/syscall.j2
@@ -1,0 +1,33 @@
+etype.exec:
+etype.initmod:
+etype.finitmod:
+etype.file:
+    send-if-matches:
+        user-authorized-keys:
+            watchpath: /home/*/.ssh/authorized_keys
+            watchfor: create, modify
+        root-authorized-keys:
+            watchpath: /root/.ssh/authorized_keys
+            watchfor: create, modify
+        cronfiles:
+            watchpath: /etc/cron*
+            depth: 2
+        systemd:
+            watchpath: /etc/systemd/*
+            depth: 2
+        boot-initd:
+            watchpath: /etc/init.d/*
+            depth: 2
+        boot-rc:
+            watchpath: /etc/rc*
+            depth: 2
+        shadow-file:
+            watchpath: /etc/shadow*
+        watchlacework:
+            watchpath: /var/lib/lacework
+            depth: 2
+        watchpasswd:
+            watchpath: /etc/passwd
+        watchsshconfig:
+            watchpath: /etc/ssh/sshd_config
+            watchfor: create, modify


### PR DESCRIPTION
Supports windows and ubuntu/debian. Used via the ansible extension.

Example (excerpt):

```
  - name: windows-run-ansible
    extension: Ansible
    source:
      location: "git+https://github.com/lacework-dev/detc-resources.git"
      subdir: "util/laceworkagent/ansible"
    helpers: []
    args:
      inventory: !lookup /win001/outputs/ip
      user: !lookup /win001/outputs/user
      winrm: true
      winrm_password: !lookupSecret /win001/outputs/password
      playbook: agent.yaml
      extra_vars:
        access_token: !secret lacework.access_token
```

Parameters:

lacework_msi_url            => Full URL to a MSI to use (mutually exclusive with lacework_agent_version, for testing)
lacework_agent_version => Agent version to use (works for windows and linux)
lacework_api_server       => API server to use
lacework_access_token  => Access Token
lacework_enable_caa      => Enable CAA (Linux Only)
syscall_template              => syscall template to use (see util/laceworkagent/ansible/templates or you can specify a URL)