### PR TITLE
fix(teardown): do not disable gcp services on destroy

### DIFF
--- a/util/tenant_setup/terraform/gcp/main.tf
+++ b/util/tenant_setup/terraform/gcp/main.tf
@@ -23,18 +23,21 @@ provider "google" {
 }
 
 resource "google_project_service" "enable-compute" {
-  project = var.project
-  service = "compute.googleapis.com"
+  project            = var.project
+  service            = "compute.googleapis.com"
+  disable_on_destroy = false
 }
 
 resource "google_project_service" "enable-k8s" {
-  project = var.project
-  service = "container.googleapis.com"
+  project            = var.project
+  service            = "container.googleapis.com"
+  disable_on_destroy = false
 }
 
 resource "google_project_service" "enable-cloudresourcemanager" {
-  project = var.project
-  service = "cloudresourcemanager.googleapis.com"
+  project            = var.project
+  service            = "cloudresourcemanager.googleapis.com"
+  disable_on_destroy = false
 }
 
 resource "google_service_account" "service_account" {


### PR DESCRIPTION
Prevents errors from shutting down APIs before cleanup is done