### PR TITLE
fix(CPLAT-672): update references to api.lacework.net

### DIFF
--- a/apps/lacework-agent-helm/values.yaml
+++ b/apps/lacework-agent-helm/values.yaml
@@ -1,5 +1,5 @@
 laceworkConfig:
-  serverUrl: {{ or .api_url "https://api.lacework.net" }}
+  serverUrl: {{ or .api_url "https://agent.lacework.net" }}
   accessToken: {{ .access_token }}
   kubernetesCluster: {{ .cluster_name }}
 {{ if eq .enable_cluster_agent "true" }}

--- a/apps/lacework/config.yml
+++ b/apps/lacework/config.yml
@@ -9,5 +9,5 @@ data:
       "autoupgrade": "disable",
       "tokens": {"AccessToken":"{{ index . "lw_access_token" }}"},
       "tags":{"Env":"k8s","KubernetesCluster":"{{.cluster_name}}"},
-      "serverurl":{{if .fra}}"https://api.fra.lacework.net"{{else}}"https://api.lacework.net"{{end}}
+      "serverurl":{{if .fra}}"https://agent.euprodn.lacework.net"{{else}}"https://agent.lacework.net"{{end}}
     }

--- a/plans/jenkins/jenkins.yaml
+++ b/plans/jenkins/jenkins.yaml
@@ -33,7 +33,7 @@ jenkins:
       default: true
     - path: lacework.api_url
       description: lacework API url
-      default: https://api.lacework.net
+      default: https://agent.lacework.net
   steps:
     - name: generate-ssh-key-pair
       extension: Ansible

--- a/plans/k8s/aks.yaml
+++ b/plans/k8s/aks.yaml
@@ -5,7 +5,7 @@ azure-k8s:
       description: lacework agent token
     - path: lacework.api_url
       description: lacework API url
-      default: https://api.lacework.net
+      default: https://agent.lacework.net
     - path: lacework.k8s_use_kubectl_agent
       description: use legacy kubectl agent install instead of helm
       default: false

--- a/plans/k8s/eks-worker.yaml
+++ b/plans/k8s/eks-worker.yaml
@@ -5,7 +5,7 @@ aws-k8s-worker:
       description: lacework agent token
     - path: lacework.api_url
       description: lacework API url
-      default: https://api.lacework.net
+      default: https://agent.lacework.net
     - path: lacework.k8s_use_kubectl_agent
       description: use legacy kubectl agent install instead of helm
       default: false

--- a/plans/k8s/eks.yaml
+++ b/plans/k8s/eks.yaml
@@ -5,7 +5,7 @@ aws-k8s:
       description: lacework agent token
     - path: lacework.api_url
       description: lacework API url
-      default: https://api.lacework.net
+      default: https://agent.lacework.net
     - path: lacework.k8s_use_kubectl_agent
       description: use legacy kubectl agent install instead of helm
       default: false

--- a/plans/k8s/gke.yaml
+++ b/plans/k8s/gke.yaml
@@ -4,7 +4,7 @@ gcp-k8s:
       description: lacework agent token
     - path: lacework.api_url
       description: lacework API url
-      default: https://api.lacework.net
+      default: https://agent.lacework.net
     - path: lacework.k8s_use_kubectl_agent
       description: use legacy kubectl agent install instead of helm
       default: false

--- a/plans/voteapp/voteapp-aks.yml
+++ b/plans/voteapp/voteapp-aks.yml
@@ -11,7 +11,7 @@ VoteAppAKS:
       default: true
     - path: lacework.api_url
       description: lacework API url
-      default: https://api.lacework.net
+      default: https://agent.lacework.net
   needs:
     - azure-k8s
   steps:

--- a/util/laceworkagent/ansible/agent.yaml
+++ b/util/laceworkagent/ansible/agent.yaml
@@ -4,7 +4,7 @@
     access_token: "{{ lacework_access_token }}"
     enable_caa: "{{ lacework_enable_caa | default(true) }}"
     syscall_template: "{{ lacework_syscall_template | default('syscall.j2') }}"
-    api_server: "{{ lacework_api_server | default('https://api.lacework.net/')}}"
+    api_server: "{{ lacework_api_server | default('https://agent.lacework.net/')}}"
     agent_version: "{{ lacework_agent_version | default('latest') }}"
     msi_url: "{{ lacework_msi_url | default(false) }}"
     msi_final_url: "{% if msi_url %}{{ msi_url }}{% elif agent_version != 'latest' %}https://updates.lacework.net/{{ agent_version }}/LWDataCollector.msi{% else %}https://updates.lacework.net/windows/latest/LWDataCollector.msi{% endif %}"


### PR DESCRIPTION
Refer CPLAT-672, we are moving from old style dns endpoints (api.lacework.net) to new style dns endpoints (agent.lacework.net)
This change updates those references.