### PR TITLE
fix: bump version of lacework terraform provider to 1.8

### DIFF
--- a/util/tenant_setup/terraform/lacework/agentless/aws/main.tf
+++ b/util/tenant_setup/terraform/lacework/agentless/aws/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lacework = {
       source  = "lacework/lacework"
-      version = "1.0.1"
+      version = "1.8.0"
     }
   }
 }


### PR DESCRIPTION
When I tried to run the exist version I got this message:

> x failed to run create: exit status 1
>
>Error: Failed to query available provider packages
>
>Could not retrieve the list of available versions for provider
>lacework/lacework: no available releases match the given constraints 1.0.1,
>~> 1.8