### PR TITLE
fix(admission-controller): only use account shortname

### DIFF
--- a/apps/lacework-admission-controller/eks-admission-controller-worker.yml
+++ b/apps/lacework-admission-controller/eks-admission-controller-worker.yml
@@ -35,7 +35,7 @@ eks-admission-controller-worker:
         name: lacework-admission-controller
         namespace: lacework
         chart: lacework/admission-controller
-        account_name: !secret lacework.account_name
+        account_name: !secret lacework.account_name,@splitdots:0
         admission_controller_token: !secret lacework.admission_controller_token
         kubectl_config_file: kube.conf
         set_args:

--- a/apps/lacework-admission-controller/eks.yaml
+++ b/apps/lacework-admission-controller/eks.yaml
@@ -35,7 +35,7 @@ eks-admission-controller:
       name: lacework-admission-controller
       namespace: lacework
       chart: lacework/admission-controller
-      account_name: !secret lacework.account_name
+      account_name: !secret lacework.account_name,@splitdots:0
       admission_controller_token: !secret lacework.admission_controller_token
       kubectl_config_file: kube.conf
       set_args:


### PR DESCRIPTION
Fixes account name when the full name is in configuration to just use short name. This is a change in the proxy-scanner binary itself to not be able to use this value; must be short name (docs: https://docs.lacework.net/onboarding/integrate-proxy-scanner#account_name).


Depends on PR: https://github.com/lacework-dev/detc/pull/166