### PR TITLE
feat(ec2): enable controlling region for instance when needed

### DIFF
--- a/extensions/ec2instance.yml
+++ b/extensions/ec2instance.yml
@@ -34,7 +34,10 @@ args:     # These automatically get passed through to the underlying ext as args
   ami_type: ### ubuntu, amazonlinux
     type: string
     required: false
-source: # Where to get the code the underlying ext should run
+  region:
+    type: string
+    required: false
+source:
   location: "git+https://github.com/lacework-dev/detc-resources.git"
   subdir: "extensions/ec2instance"
 extension: # Core extension name/args to set.  These args are static vs the supplied ones above

--- a/extensions/ec2instance/main.tf
+++ b/extensions/ec2instance/main.tf
@@ -9,6 +9,13 @@ variable "public_ip" { default = true }
 variable "root_vol_size" { default = 40 }
 variable "tags" { default = "" }
 variable "ami_type" { default = "ubuntu" }
+variable "region" {
+  default = ""
+}
+
+provider "aws" {
+  region = var.region
+}
 
 resource "tls_private_key" "keypair" {
   algorithm = "RSA"


### PR DESCRIPTION
If region is _not_ provided, use the default region associated with the provider.