### PR TITLE
fix: voteapp worker now installs Chocolatey version 1 explicitly as d…

### DIFF
--- a/apps/voteapp/ansible/voteapp_worker.yml
+++ b/apps/voteapp/ansible/voteapp_worker.yml
@@ -2,6 +2,14 @@
 - name: provision voteapp worker
   hosts: all
   tasks:
+    - name: Install Chocolatey version 1
+      block:
+      - name: install Chocolatey CLI v1.4.0
+        win_chocolatey:
+          name: 'chocolatey'
+          state: present
+          version: '1.4.0'
+
     - name: Install dotnet-sdk
       win_chocolatey:
         name:


### PR DESCRIPTION
…efault is to install Chocolatey 2.0 that needs .NET 4.8